### PR TITLE
Fix new releases version have leading "v"

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -2,15 +2,26 @@
 
 set -euo pipefail
 
+readonly NEW_VERSION_FORMAT_START=3.5.0
+
 [ -z "${ASDF_INSTALL_TYPE+x}" ] && echo "ASDF_INSTALL_TYPE is required" && exit 1
 [ -z "${ASDF_INSTALL_VERSION+x}" ] && echo "ASDF_INSTALL_VERSION is required" && exit 1
 [ -z "${ASDF_INSTALL_PATH+x}" ] && echo "ASDF_INSTALL_PATH is required" && exit 1
+
+semver_gte() {
+  # return true if semver $1 >= $2
+  local v1=$(echo "${1//./ }" | xargs printf "%d%03d%03d")
+  local v2=$(echo "${2//./ }" | xargs printf "%d%03d%03d")
+  (( $v1 >= $v2))
+}
 
 install() {
   local install_type=$1
   [ "$install_type" != "version" ] && echo "install type, $install_type, is not supported" && exit 1
 
-  local version=$2
+  local version=${2//v/}
+  semver_gte "$version" "$NEW_VERSION_FORMAT_START" && version="v${version}"
+
   local install_path=$3
 
   local bin_install_path="$install_path/bin"

--- a/bin/list-all
+++ b/bin/list-all
@@ -9,7 +9,7 @@ fi
 cmd="$cmd $releases_path"
 
 function sort_versions() {
-  sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/\n/ /' | \
+  sed 's/^v//; h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/\n/ /' | \
     LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
 }
 


### PR DESCRIPTION
There's a small bug with `asdf install sops latest`

```
asdf version
v0.8.0-c6145d0

asdf list-all sops
3.0.0
3.0.1
3.0.2
3.0.3
3.0.4
3.0.5
3.1.0
3.1.1
3.2.0
3.3.0
3.3.1
3.4.0
v3.5.0
v3.6.0
v3.6.1

asdf install sops latest
Downloading sops from https://github.com/mozilla/sops/releases/download/3.4.0/sops-3.4.0.darwin
```

I fixed this and made sure it's backward compatible with .tool-versions files that already have leading 'v's.
