### PR TITLE
Adapt to upstream version tagging changes

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -10,7 +10,13 @@ install() {
   local install_type=$1
   [ "$install_type" != "version" ] && echo "install type, $install_type, is not supported" && exit 1
 
+  # Note that we're adding back the 'v' tag prefix only for versions > 3.4
   local version=$2
+  if [[ ! (${version} =~ [1-3]\.[0-4]) ]]; then
+    # version is greater than 3.4.0
+    version="v${version}"
+  fi
+
   local install_path=$3
 
   local bin_install_path="$install_path/bin"

--- a/bin/list-all
+++ b/bin/list-all
@@ -13,5 +13,6 @@ function sort_versions() {
     LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
 }
 
-echo $(eval "$cmd" | grep -oE "tag_name\": \".{1,15}\"," | grep -v "2.0.10" | sed 's/tag_name\": \"//;s/\",//' | sort_versions)
+# stripping off the 'v' prefix as it causes issues with 'asdf install foo latest'
+echo $(eval "$cmd" | grep -oE "tag_name\": \".{1,15}\"," | grep -v "2.0.10" | sed 's/tag_name": "//; s/^v//; s/",//' | sort_versions)
 


### PR DESCRIPTION
Hey @feniix! I noticed that the latest releases were no longer showing up. It turns out the tagging scheme for `sops` was [changed to prepend a `v`](https://github.com/mozilla/sops/releases/tag/v3.5.0) which breaks the regex in `list-all`.

I added to the `sed` to strip this now prefix and a simple check during install to add it back so that the `curl` works.

Lastly, I also removed the escaping of double quotation marks in the `sed` command since the expression is in single quotes and they don't require escaping. I tested this with both GNU sed and OS X (BSD) sed.