### PR TITLE
`asdf install sops <version>` should fail if the version does not exist

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -31,7 +31,7 @@ install() {
   mkdir -p "${bin_install_path}"
 
   echo "Downloading sops from ${download_url}"
-  curl -sL "$download_url" -o "$bin_path"
+  curl -sfL "$download_url" -o "$bin_path" || >&2 echo "Error: URL responded exceptionally"
   chmod +x "$bin_path"
 }
 


### PR DESCRIPTION
When using this utility, I noticed that `asdf sops install anything` will return success, but it will create an executing file with the text `Not Found`.

This change introduces the [curl -f](https://curl.se/docs/manpage.html#-f) flag and a friendly error message should the URL return a status code other than 200

Tested locally

```shell
~ bin_path=./test
~ download_url=https://github.com/mozilla/sops/releases/download/v0.14.11/sops-v0.14.11.darwin
~ curl -sfL "$download_url" -o "$bin_path" || >&2 echo "Error: URL responded exceptionally" # fails
Error: URL responded exceptionally
~ ➭ ls ./test
ls: ./test: No such file or directory
~ download_url=https://github.com/mozilla/sops/releases/download/v3.5.0/sops-v3.5.0.darwin
~ curl -sfL "$download_url" -o "$bin_path" || >&2 echo "Error: URL responded exceptionally" # succeeds
~ ➭ ls ./test
./test
```