### PR TITLE
fix: Add 'v' prefix for versions greater than 3.4.0

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -12,7 +12,10 @@ install_sops() {
 
   # Note that we're adding back the 'v' tag prefix only for versions > 3.4
   local version=$2
-  if [[ ! (${version} =~ [1-3]\.[0-4]) ]]; then
+  local major_version=$(echo ${version} | cut -d. -f1)
+  local minor_version=$(echo ${version} | cut -d. -f2)
+
+  if [[ "${major_version}" -gt 3 || ("${major_version}" -eq 3 && "${minor_version}" -gt 4) ]]; then
     # version is greater than 3.4.0
     version="v${version}"
   fi


### PR DESCRIPTION
This PR fixes a bug where the logic to determine if a version is greater than 3.4.0 did not work correctly when the minor version starts with 1, such as in version 3.10.1.

- Close #16 